### PR TITLE
Add a more descriptive README.md pointing to the proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio.svg?style=social&label=Follow&style=for-the-badge)](https://twitter.com/strimziio)
 
-# Strimzi Template repository
+# Proxy-Based Kafka Per-Topic Encryption
 
-This repository is currently empty
+**This project is under development!**
+
+This repository is used for development of a proxy for at-rest encryption of Kafka topics as described in the [Strimzi proposal #17](https://github.com/strimzi/proposals/blob/master/017-kafka-topic-encryption.md).


### PR DESCRIPTION
This PR adds slightly more descriptive README.md which links to the proposal. This should be replaced by something better as the work starts, but it should at least explain what to expect if someone visits the repo without reading the proposal first.