### PR TITLE
Tolerate >1 protocol msgs arriving in one Buffer

### DIFF
--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageAccumulator.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageAccumulator.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.kafka.proxy.vertx;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,32 +21,54 @@ public class MessageAccumulator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageAccumulator.class);
 
+    // SIZE_LEN is the size (in bytes) of the field used to describe the length of the
+    // proceeding Kafka request or response data.
+    // See: https://kafka.apache.org/protocol.html#protocol_common
+    private static final int SIZE_LEN = 4;
+
     private Buffer buffer;
-    
+
     public MessageAccumulator() {
         buffer = Buffer.buffer(0);
     }
-    
+
     public void append(Buffer buffer) {
         if (LOGGER.isDebugEnabled()) {
             LogUtils.hexDump("Msg append", buffer);
         }
         this.buffer.appendBuffer(buffer);
     }
- 
-    public boolean isComplete() {
-        return MsgUtil.isBufferComplete(buffer);
-    }
-    
-    public Buffer getBuffer() {
-        return buffer;
-    }
-    
-    public void reset() {
-        buffer = Buffer.buffer(0);
-    }
-    
-    public boolean isEmpty() {
-        return buffer.length() == 0;
+
+    /**
+     * @return a list containing the complete Kafka protocol messages accumulated.
+     *         These are removed from the accumulator.
+     */
+    public List<Buffer> take() {
+        int pos = 0;
+        int remaining = buffer.length();
+        ArrayList<Buffer> result = new ArrayList<>();
+        while(remaining > 0) {
+            if (remaining < SIZE_LEN) {
+                break;
+            }
+
+            int nextMsgLen = buffer.getInt(pos);
+            if (nextMsgLen+SIZE_LEN > remaining) {
+                break;
+            }
+
+            result.add(buffer.slice(pos, pos+nextMsgLen+SIZE_LEN));
+
+            remaining -= nextMsgLen+SIZE_LEN;
+            pos += nextMsgLen+SIZE_LEN;
+        }
+
+        if (pos == buffer.length()) {
+            buffer = Buffer.buffer(0);
+        } else {
+            buffer = buffer.getBuffer(pos, buffer.length());
+        }
+
+        return result;
     }
 }

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageAccumulator.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageAccumulator.java
@@ -52,15 +52,15 @@ public class MessageAccumulator {
                 break;
             }
 
-            int nextMsgLen = buffer.getInt(pos);
-            if (nextMsgLen+SIZE_LEN > remaining) {
+            int nextMsgLen = buffer.getInt(pos) + SIZE_LEN;
+            if (nextMsgLen > remaining) {
                 break;
             }
 
-            result.add(buffer.slice(pos, pos+nextMsgLen+SIZE_LEN));
+            result.add(buffer.slice(pos, pos+nextMsgLen));
 
-            remaining -= nextMsgLen+SIZE_LEN;
-            pos += nextMsgLen+SIZE_LEN;
+            remaining -= nextMsgLen;
+            pos += nextMsgLen;
         }
 
         if (pos == buffer.length()) {

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageHandler.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageHandler.java
@@ -117,24 +117,23 @@ public class MessageHandler implements Handler<Buffer> {
         LOGGER.debug("Request buffer from client arrived");
         currClientReq.append(buffer);
 
-        boolean isComplete = currClientReq.isComplete();
-        LOGGER.debug("Kafka msg complete {}", isComplete);
-        if (!isComplete) {
+        List<Buffer> sendBuffers = currClientReq.take();
+        LOGGER.debug("Number of complete Kafka msgs: {}", sendBuffers.size());
+        if (sendBuffers.isEmpty()) {
             return;
         }
 
-        // We have a complete kafka msg - process it, forward to broker
-        Buffer sendBuffer = null;
-        try {
-            sendBuffer = processRequest(currClientReq.getBuffer());
-        } catch (EncSerDerException | GeneralSecurityException e) {
-            LOGGER.error("Encryption error processing request", e);
-            // to do: send back Kafka error msg
-            return;
-        } finally {
-            currClientReq.reset();
+        for (Buffer sendBuffer : sendBuffers) {
+            // We have a complete kafka msg - process it, forward to broker
+            try {
+                sendBuffer = processRequest(sendBuffer);
+            } catch (EncSerDerException | GeneralSecurityException e) {
+                LOGGER.error("Encryption error processing request", e);
+                // to do: send back Kafka error msg
+                return;
+            }
+            forwardToBroker(sendBuffer);
         }
-        forwardToBroker(sendBuffer);
     }
 
     /**
@@ -297,43 +296,43 @@ public class MessageHandler implements Handler<Buffer> {
 
         // accumulate message fragments
         currBrokerRsp.append(brokerRsp);
-        if (!currBrokerRsp.isComplete()) {
+
+        List<Buffer> brokerRspMsgs = currBrokerRsp.take();
+        if (brokerRspMsgs.isEmpty()) {
             return;
         }
 
-        // if this far, we have a complete message. process it.
-        Buffer brokerRspMsg = currBrokerRsp.getBuffer();
+        // process all the messages returned by the accumulator
+        for (Buffer brokerRspMsg : brokerRspMsgs) {
+            int corrId = MsgUtil.getRspCorrId(brokerRspMsg);
+            if (corrId != -1) {
+                RequestHeader reqHeader = fetchHeaderCache.get(corrId);
+                if (reqHeader != null) {
+                    // The response matches a recently cached fetch request.
+                    LOGGER.debug("Broker response matches cached FETCH req header corrId={}", corrId);
+                    fetchHeaderCache.remove(corrId);
 
-        int corrId = MsgUtil.getRspCorrId(brokerRspMsg);
-        if (corrId != -1) {
-            RequestHeader reqHeader = fetchHeaderCache.get(corrId);
-            if (reqHeader != null) {
-                // The response matches a recently cached fetch request.
-                LOGGER.debug("Broker response matches cached FETCH req header corrId={}", corrId);
-                fetchHeaderCache.remove(corrId);
-
-                // call enc module for decryption:
-                brokerRspMsg = processFetchResponse(brokerRspMsg, reqHeader);
+                    // call enc module for decryption:
+                    brokerRspMsg = processFetchResponse(brokerRspMsg, reqHeader);
+                }
             }
+
+            // Finished with broker response processing.
+            // Forward to the Kafka client.
+            Future<Void> writeFuture = clientSocket.write(brokerRspMsg);
+
+            // logging:
+            final Buffer rspBuf = brokerRspMsg;
+            writeFuture.onSuccess(h -> {
+                if (LOGGER.isDebugEnabled()) {
+                    String msg = String.format(
+                            "proxy->client: broker response corrId=%d (%02X), thread = %s, socket=%s",
+                            corrId, corrId, Thread.currentThread().getName(),
+                            clientSocket.remoteAddress().toString());
+                    LogUtils.hexDump(msg, rspBuf);
+                }
+            });
         }
-
-        // Finished with broker response processing.
-        // Forward to the Kafka client.
-        Future<Void> writeFuture = clientSocket.write(brokerRspMsg);
-
-        // logging:
-        final Buffer rspBuf = brokerRspMsg;
-        writeFuture.onSuccess(h -> {
-            if (LOGGER.isDebugEnabled()) {
-                String msg = String.format(
-                        "proxy->client: broker response corrId=%d (%02X), thread = %s, socket=%s",
-                        corrId, corrId, Thread.currentThread().getName(),
-                        clientSocket.remoteAddress().toString());
-                LogUtils.hexDump(msg, rspBuf);
-            }
-        });
-        // reset the broker rsp buffer:
-        currBrokerRsp.reset();
     }
 
     /**

--- a/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/MessageAccumulatorTest.java
+++ b/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/MessageAccumulatorTest.java
@@ -1,0 +1,118 @@
+package io.strimzi.kafka.proxy.vertx;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.vertx.core.buffer.Buffer;
+
+public class MessageAccumulatorTest {
+
+    @Test
+    public void newAccumulatorReturnsNoMessages() {
+        MessageAccumulator acc = new MessageAccumulator();
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(Collections.EMPTY_LIST, actualMessages);
+    }
+
+    @Test
+    public void fewerBytesThatACompleteSizeValueReturnsNoMessages() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{0x00}));
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(Collections.EMPTY_LIST, actualMessages);
+    }
+
+    // Requests or responses with zero length should not occur in the Kafka
+    // protocol. Test that the MessageAccumulator class does something sensible
+    // if it encounters one.
+    @Test
+    public void zeroSizeMessage() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{0x00, 0x00, 0x00, 0x00}));
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(1, actualMessages.size());
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x00}, actualMessages.get(0).getBytes());
+    }
+
+    @Test
+    public void exactlyOneMessage() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{0x00, 0x00, 0x00, 0x01, 0x02}));
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(1, actualMessages.size());
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x01, 0x02}, actualMessages.get(0).getBytes());
+
+        List<Buffer> furtherMessages = acc.take();
+        assertEquals(Collections.EMPTY_LIST, furtherMessages);
+    }
+
+    @Test
+    public void notQuiteTwoMessages() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{
+            0x00, 0x00, 0x00, 0x01, 0x02,
+            0x00, 0x00, 0x00, 0x02,
+        }));
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(1, actualMessages.size());
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x01, 0x02}, actualMessages.get(0).getBytes());
+
+        List<Buffer> furtherMessages = acc.take();
+        assertEquals(Collections.EMPTY_LIST, furtherMessages);
+    }
+
+    @Test
+    public void exactlyTwoMessages() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{
+            0x00, 0x00, 0x00, 0x01, 0x02,
+            0x00, 0x00, 0x00, 0x02, 0x03, 0x04,
+        }));
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertEquals(2, actualMessages.size());
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x01, 0x02}, actualMessages.get(0).getBytes());
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x02, 0x03, 0x04}, actualMessages.get(1).getBytes());
+    }
+
+    @Test
+    public void twoMessagesAccumulatedInSmallPieces() {
+        MessageAccumulator acc = new MessageAccumulator();
+        acc.append(Buffer.buffer(new byte[]{
+            0x00, 0x00, 0x00, 0x01})); // incomplete first message
+
+        assertEquals(Collections.EMPTY_LIST, acc.take()); // no messages returned
+
+        acc.append(Buffer.buffer(new byte[]{
+            0x02,                      // completes first message
+            0x00, 0x00, 0x00, 0x02})); // incomplete second message
+
+        List<Buffer> actualMessages = acc.take();
+
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x01, 0x02}, actualMessages.get(0).getBytes());
+        assertEquals(Collections.EMPTY_LIST, acc.take()); // no more messages
+
+        acc.append(Buffer.buffer(new byte[]{
+            0x03, 0x04})); // incomplete second message
+
+        actualMessages = acc.take();
+        assertArrayEquals(new byte[]{0x00, 0x00, 0x00, 0x02, 0x03, 0x04}, actualMessages.get(0).getBytes());
+        assertEquals(Collections.EMPTY_LIST, acc.take()); // no more messages
+    }
+}


### PR DESCRIPTION
Change `MessageAccumulator` to handle arbitrary partitions of one
or more Kafka protocol messages across calls to `append(...)`. This
fixes a bug where if data for more than one message is present in
the buffer passed to `append(...)`, then the accumulator will return
no further data.