### PR TITLE
Generate correct response header

### DIFF
--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MsgUtil.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MsgUtil.java
@@ -125,7 +125,7 @@ public class MsgUtil {
      * @return
      */
     private static ByteBuffer serialize(FetchResponse<?> fetchRsp, RequestHeader reqHeader) {
-        ResponseHeader rspHeader = new ResponseHeader(reqHeader.correlationId(), reqHeader.apiVersion());
+        ResponseHeader rspHeader = reqHeader.toResponseHeader();
         //System.out.println("****** req: " + reqHeader.apiVersion() + " rsp: " + rspHeader.headerVersion());
         return RequestUtils.serialize(rspHeader.data(), rspHeader.headerVersion(), fetchRsp.data(), reqHeader.apiVersion());
     }


### PR DESCRIPTION
The response header version is not the same as the API version (but it
can be derived from it). Since `RequestHeader` provides a convenient way
to build a response header, use this instead.

Signed-off-by: Adrian Preston <prestona@uk.ibm.com>