### PR TITLE
Fix message header size calculation

### DIFF
--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsg.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsg.java
@@ -30,7 +30,11 @@ public class AbstractKafkaMsg {
 	    }
 		return payload;
 	}
-		
+
+	protected short getAPIKey() {
+		return rawMsg.getShort(4);
+	}
+
 	protected ByteBuffer extractKafkaPayload(Buffer kafkaMsg) {
 		// copy bytes after leading 4 bytes containing message len:
 		byte[] dataBytes = Arrays.copyOfRange(kafkaMsg.getBytes(), 4, kafkaMsg.getBytes().length);

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsg.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsg.java
@@ -31,7 +31,7 @@ public class AbstractKafkaMsg {
 		return payload;
 	}
 
-	protected short getAPIKey() {
+	protected short getApiKey() {
 		return rawMsg.getShort(4);
 	}
 

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsg.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsg.java
@@ -5,6 +5,8 @@
 package io.strimzi.kafka.proxy.vertx;
 
 import java.util.Arrays;
+
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.RequestHeader;
 import io.vertx.core.buffer.Buffer;
 
@@ -26,12 +28,19 @@ public class KafkaReqMsg extends AbstractKafkaMsg {
         return header;
     }
 
+    protected short getAPIVersion() {
+		return rawMsg.getShort(6);
+	}
+
     public byte[] getHeaderBytes() {
         if (headerBytes == null) {
-            // to do: clarify +1
-            int headerSize = FIXED_HEADER_LEN + getClientIdLen();
-            int destIndex = MSG_SIZE_LEN + headerSize + 1;
-            headerBytes = Arrays.copyOfRange(rawMsg.getBytes(), MSG_SIZE_LEN, destIndex);
+            int tagBufferSize = 0;
+            short headerVersion = ApiKeys.forId((int)getAPIKey()).requestHeaderVersion(getAPIVersion());
+            if (headerVersion >= 2) {
+                tagBufferSize = 1;
+            }
+            int headerSize = FIXED_HEADER_LEN + getClientIdLen() + tagBufferSize;
+            headerBytes = Arrays.copyOfRange(rawMsg.getBytes(), MSG_SIZE_LEN, MSG_SIZE_LEN + headerSize);
         }
         return headerBytes;
     }

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsg.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsg.java
@@ -28,14 +28,14 @@ public class KafkaReqMsg extends AbstractKafkaMsg {
         return header;
     }
 
-    protected short getAPIVersion() {
+    private short getApiVersion() {
 		return rawMsg.getShort(6);
 	}
 
     public byte[] getHeaderBytes() {
         if (headerBytes == null) {
             int tagBufferSize = 0;
-            short headerVersion = ApiKeys.forId((int)getAPIKey()).requestHeaderVersion(getAPIVersion());
+            short headerVersion = ApiKeys.forId((int)getApiKey()).requestHeaderVersion(getApiVersion());
             if (headerVersion >= 2) {
                 tagBufferSize = 1;
             }

--- a/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsgTest.java
+++ b/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/AbstractKafkaMsgTest.java
@@ -1,0 +1,72 @@
+package io.strimzi.kafka.proxy.vertx;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.RequestUtils;
+import org.junit.Test;
+
+import io.netty.buffer.Unpooled;
+import io.vertx.core.buffer.Buffer;
+
+public class AbstractKafkaMsgTest {
+
+    @Test
+    public void getRawMsg() {
+        // getRawMsg doesn't validate the data is a valid Kafka message, so just
+        // use any sequence of bytes in this test.
+        byte[] expectedRawMsg = new byte[]{0x01, 0x02, 0x03};
+        AbstractKafkaMsg akm = new AbstractKafkaMsg(Buffer.buffer(expectedRawMsg));
+
+        byte[] actualRawMsg = akm.getRawMsg().getBytes();
+
+        assertArrayEquals(expectedRawMsg, actualRawMsg);
+    }
+
+    @Test
+    public void getPayload() {
+        // getPayload considers anything past the first 4 bytes as the payload
+        // so this isn't an accurate rendering of a Kafka protocol message
+        byte[] expectedPayload = new byte[]{
+            0x01, 0x02, 0x03, 0x04
+        };
+        Buffer msg = Buffer.buffer().appendInt(expectedPayload.length).appendBytes(expectedPayload);
+        AbstractKafkaMsg akm = new AbstractKafkaMsg(msg);
+
+        ByteBuffer actualPayloadBB = akm.getPayload();
+        byte[] actualPayload = new byte[actualPayloadBB.remaining()];
+        actualPayloadBB.get(actualPayload);
+
+        assertArrayEquals(expectedPayload, actualPayload);
+    }
+
+    // Helper for serializing a RequestHeader / Request to a Buffer.
+    static Buffer serializeToBuffer(RequestHeader rh, AbstractRequest req) {
+        ByteBuffer reqBB = RequestUtils.serialize(rh.data(), rh.apiVersion(), req.data(), rh.apiVersion());
+        return Buffer.buffer()
+            .appendInt(reqBB.remaining())
+            .appendBuffer(Buffer.buffer(Unpooled.copiedBuffer(reqBB)));
+    }
+
+    @Test
+    public void getApiKey() {
+        // Generate more realistic test data to make sure that the API key
+        // value is pulled from the correct offset.
+        RequestHeader rh = new RequestHeader(ApiKeys.FETCH, (short)12, "clientId", 1);
+        FetchRequest fr = new FetchRequest.Builder(
+            rh.apiVersion(), rh.apiVersion(), 0, 500, 1, new HashMap<>()).build();
+
+        AbstractKafkaMsg akm = new AbstractKafkaMsg(serializeToBuffer(rh, fr));
+
+        short actualApiKey = akm.getApiKey();
+
+        assertEquals(fr.apiKey().id, actualApiKey);
+    }
+}

--- a/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsgTest.java
+++ b/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/KafkaReqMsgTest.java
@@ -1,0 +1,61 @@
+package io.strimzi.kafka.proxy.vertx;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.charset.Charset;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.DataOutputStreamWritable;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.junit.Test;
+
+public class KafkaReqMsgTest {
+
+    @Test
+    public void getHeader() {
+        RequestHeader expectedRH = new RequestHeader(ApiKeys.PRODUCE, (short)8, "clientId", 7);
+        ProduceRequest pr =
+            new ProduceRequest.Builder(expectedRH.apiVersion(), expectedRH.apiVersion(), new ProduceRequestData()).build();
+        KafkaReqMsg reqMsg = new KafkaReqMsg(AbstractKafkaMsgTest.serializeToBuffer(expectedRH, pr));
+
+        RequestHeader actualRH = reqMsg.getHeader();
+
+        assertEquals(expectedRH, actualRH);
+    }
+
+    @Test
+    public void getHeaderBytes() {
+        short[] requestVersions = new short[] {
+            8, // -> uses request header v1
+            9, // -> uses request header v2
+        };
+        String[] clientIds = new String[] {"clientId", null};
+
+        for (int i = 0; i < requestVersions.length; i++) {
+            RequestHeader rh =
+                new RequestHeader(ApiKeys.PRODUCE, requestVersions[i], clientIds[i], 7);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            if (clientIds[i] != null) {
+                cache.cacheSerializedValue(clientIds[i], clientIds[i].getBytes(Charset.forName("UTF-8")));
+            }
+            try (DataOutputStreamWritable dosw = new DataOutputStreamWritable(new DataOutputStream(baos))) {
+                rh.data().write(dosw, cache, rh.headerVersion());
+            }
+            byte[] expectedHeaderBytes = baos.toByteArray();
+            ProduceRequest pr = new ProduceRequest.Builder(
+               rh.apiVersion(), rh.apiVersion(), new ProduceRequestData()).build();
+            KafkaReqMsg reqMsg = new KafkaReqMsg(AbstractKafkaMsgTest.serializeToBuffer(rh, pr));
+
+            byte[] actualHeaderBytes = reqMsg.getHeaderBytes();
+
+            assertArrayEquals(expectedHeaderBytes, actualHeaderBytes);
+        }
+    }
+}


### PR DESCRIPTION
The extra byte (to indicate no tagged fields) was introduced in version
2 of the request header. Depending on the versions of client and broker
being used this byte may, or may not, be present. Use the API key and
request API version to determine if the byte should be present in the
request header, rather than assuming it will always be there.

Signed-off-by: Adrian Preston prestona@uk.ibm.com