### PR TITLE
Upgrade to kafka-clients 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>3.4.0</kafka.version>
         
         <spotbugs.version>4.7.1</spotbugs.version>
         <fasterxml.jackson-core.version>2.13.3</fasterxml.jackson-core.version>

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageHandler.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/MessageHandler.java
@@ -366,7 +366,7 @@ public class MessageHandler implements Handler<Buffer> {
             throws EncSerDerException, GeneralSecurityException, KmsException {
         // instantiate FetchResponse instance
         KafkaRspMsg rsp = new KafkaRspMsg(buffer, reqHeader.apiVersion());
-        FetchResponse<?> fetch = (FetchResponse<?>) AbstractResponse.parseResponse(rsp.getPayload(),
+        FetchResponse fetch = (FetchResponse) AbstractResponse.parseResponse(rsp.getPayload(),
                 reqHeader);
 
         // iterate through response records, decrypting where needed

--- a/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/msg/MsgUtil.java
+++ b/vertx-proxy/src/main/java/io/strimzi/kafka/proxy/vertx/msg/MsgUtil.java
@@ -106,7 +106,7 @@ public class MsgUtil {
      * @param req
      * @return
      */
-    public static Buffer toSendBuffer(FetchResponse<?> fetchRsp, RequestHeader reqHeader) {
+    public static Buffer toSendBuffer(FetchResponse fetchRsp, RequestHeader reqHeader) {
         ByteBuffer serializedRsp = serialize(fetchRsp, reqHeader);
         byte[] rspBytes = serializedRsp.array();
         int bufLen = Integer.BYTES + rspBytes.length;
@@ -124,7 +124,7 @@ public class MsgUtil {
      * @param fetchRsp
      * @return
      */
-    private static ByteBuffer serialize(FetchResponse<?> fetchRsp, RequestHeader reqHeader) {
+    private static ByteBuffer serialize(FetchResponse fetchRsp, RequestHeader reqHeader) {
         ResponseHeader rspHeader = reqHeader.toResponseHeader();
         //System.out.println("****** req: " + reqHeader.apiVersion() + " rsp: " + rspHeader.headerVersion());
         return RequestUtils.serialize(rspHeader.data(), rspHeader.headerVersion(), fetchRsp.data(), reqHeader.apiVersion());

--- a/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/EncModTest.java
+++ b/vertx-proxy/src/test/java/io/strimzi/kafka/proxy/vertx/EncModTest.java
@@ -90,7 +90,7 @@ public class EncModTest {
 
         // instantiate the decrypted fetch response
         KafkaRspMsg rsp = new KafkaRspMsg(fetchRspBuf, reqHeader.apiVersion());
-        FetchResponse<?> fetch = (FetchResponse<?>) AbstractResponse.parseResponse(rsp.getPayload(),
+        FetchResponse fetch = (FetchResponse) AbstractResponse.parseResponse(rsp.getPayload(),
                 reqHeader);
 
         FetchResponseData data = fetch.data();
@@ -102,8 +102,8 @@ public class EncModTest {
         // This tests the integrity of the decrypted response.
         List<FetchableTopicResponse> responses = data.responses();
         for (FetchableTopicResponse topicRsp : responses) {
-            topicRsp.partitionResponses().forEach(pd -> {
-                MemoryRecords recs = (MemoryRecords) pd.recordSet();
+            topicRsp.partitions().forEach(pd -> {
+                MemoryRecords recs = (MemoryRecords) pd.records();
                 recs.records().forEach(r -> {
                     if (r.hasValue()) {
                         byte[] recordData = new byte[r.valueSize()];


### PR DESCRIPTION
This is an enabler for integration with the kroxylicious proxy framework because it depends on kafka-clients too, causing problems at runtime if we try to call the EncryptionModule built against an older kafka-clients.

Note: topic-encryption with the vertx-proxy will still require the proxied Kafka cluster or client to be less that version 3.1.0 because it does not yet work with topic ids in the FetchResponse (see #17 ).